### PR TITLE
Sorting tests

### DIFF
--- a/chain/contracts/Awards.sol
+++ b/chain/contracts/Awards.sol
@@ -3,8 +3,14 @@ pragma solidity ^0.8.9;
 
 import '@openzeppelin/contracts/token/ERC721/ERC721.sol';
 import './Competitions.sol';
-import 'hardhat/console.sol';
 
+/* 
+This is a possible implementation of NFT smart contract which mints
+tokens for competition winners. Tokens include information about:
+- competition name
+- number of votes a team has got
+- team's rank in the competition
+ */
 contract Awards is ERC721 {
   struct Prize {
     string competitionName;

--- a/chain/contracts/Competitions.sol
+++ b/chain/contracts/Competitions.sol
@@ -105,7 +105,7 @@ contract Competitions is Ownable {
     Competition storage contest = competitions[nameHash];
     require(
       governor.state(contest.proposalId) == IGovernor.ProposalState.Succeeded,
-      'Voting is still active or quorum was not reached'
+      'Proposal is not ready to be executed'
     );
     (
       address[] memory targets,

--- a/chain/contracts/GovernorBallot.sol
+++ b/chain/contracts/GovernorBallot.sol
@@ -20,7 +20,7 @@ contract GovernorBallot is
     Governor('GovernorBallot')
     GovernorSettings(1 /* 1 block */, 20 /* 10 minutes */, 0)
     GovernorVotes(_token)
-    GovernorVotesQuorumFraction(10)
+    GovernorVotesQuorumFraction(6)
   {}
 
   // The following functions are overrides required by Solidity.

--- a/chain/contracts/GovernorBallot.sol
+++ b/chain/contracts/GovernorBallot.sol
@@ -20,7 +20,7 @@ contract GovernorBallot is
     Governor('GovernorBallot')
     GovernorSettings(1 /* 1 block */, 20 /* 10 minutes */, 0)
     GovernorVotes(_token)
-    GovernorVotesQuorumFraction(4)
+    GovernorVotesQuorumFraction(10)
   {}
 
   // The following functions are overrides required by Solidity.

--- a/chain/contracts/GovernorCountingBallot.sol
+++ b/chain/contracts/GovernorCountingBallot.sol
@@ -3,6 +3,10 @@ pragma solidity ^0.8.9;
 
 import '@openzeppelin/contracts/governance/Governor.sol';
 
+/* 
+Modified Governor Voting module where instead of answering for/against/abstain
+a voter can select one of 255 alternatives (0 - 255, where 0 is abstain)
+ */
 abstract contract GovernorCountingBallot is Governor {
   struct ProposalVote {
     uint256 totalVotes;

--- a/chain/test/Competitions.winners.test.ts
+++ b/chain/test/Competitions.winners.test.ts
@@ -1,0 +1,112 @@
+import hre from 'hardhat';
+import { mine, loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { expect } from 'chai';
+import {
+  GovernorBallot,
+  VoteToken,
+  Competitions,
+  Awards,
+} from '../typechain-types';
+import { deploy } from './util';
+
+describe('Competitions. Sorting team results. Finding winners', () => {
+  let governor: GovernorBallot;
+  let voteToken: VoteToken;
+  let competitions: Competitions;
+  let awards: Awards;
+  let teams: string[];
+  let competitionName: string;
+
+  before(async () => {
+    const contracts = await loadFixture(deploy);
+    governor = contracts.governor;
+    voteToken = contracts.voteToken;
+    competitions = contracts.competitions;
+    awards = contracts.awards;
+  });
+
+  it('should delegate voting power', async () => {
+    const signers = await hre.ethers.getSigners();
+    await Promise.all(
+      signers.map(async (signer) => {
+        const tx = await voteToken.connect(signer).delegate(signer.address);
+        await expect(tx).to.emit(voteToken, 'DelegateChanged');
+        expect(await voteToken.getVotes(signer.address)).to.equal(1);
+      }),
+    );
+  });
+
+  it('should start a competition', async () => {
+    competitionName = 'Competition 1';
+    // 10 teams are participating
+    teams = (await hre.ethers.getSigners()).slice(1, 11).map((s) => s.address);
+    const tx = competitions.startCompetition(teams, competitionName);
+    await expect(tx).to.emit(governor, 'ProposalCreated');
+  });
+
+  it('voters should vote for different teams', async () => {
+    /* 
+    there are 10 teams in total
+    3 of them have the same score of 5
+    and the other 7 of them have the same score of 0
+    */
+    await mine(2);
+    const signers = await hre.ethers.getSigners();
+    const propId = await competitions.getProposalId(competitionName);
+    const vote = async (signerIndex: number, suppport: number) => {
+      await expect(
+        governor.connect(signers[signerIndex]).castVote(propId, suppport),
+      )
+        .to.emit(governor, 'VoteCast')
+        .withArgs(signers[signerIndex].address, propId, suppport, 1, '');
+    };
+    // 5 voters give votes to the team 5
+    await vote(0, 5);
+    await vote(1, 5);
+    await vote(2, 5);
+    await vote(3, 5);
+    await vote(4, 5);
+    // 5 voters vote for team 4
+    await vote(5, 4);
+    await vote(6, 4);
+    await vote(7, 4);
+    await vote(8, 4);
+    await vote(9, 4);
+    // 5 voters vote for team 10
+    await vote(10, 10);
+    await vote(11, 10);
+    await vote(12, 10);
+    await vote(13, 10);
+    await vote(14, 10);
+    // other teams don't have votes
+  });
+
+  it('should execute the proposal and mint NFTs to the winners', async () => {
+    await mine(20);
+    const tx = await competitions.endCompetition(competitionName);
+    await expect(tx).to.emit(governor, 'ProposalExecuted');
+    await expect(tx).to.emit(awards, 'Transfer');
+  });
+
+  it('teams should receive their minted NFTs', async () => {
+    const checkNftMint = async (
+      teamIndex: number,
+      rank: number,
+      votingResult: number,
+    ) => {
+      const index = teamIndex - 1;
+      const id = hre.ethers.utils.solidityKeccak256(
+        ['string', 'address', 'uint8'],
+        [competitionName, teams[index], rank],
+      );
+      expect(await awards.ownerOf(id)).to.equal(teams[index]);
+      const prize0 = await awards.prizes(id);
+      expect(prize0.competitionName).to.equal(competitionName);
+      expect(prize0.votingResult).to.equal(votingResult);
+      expect(prize0.rank).to.equal(rank);
+    };
+    await checkNftMint(5, 1, 5);
+    await checkNftMint(4, 1, 5);
+    await checkNftMint(10, 1, 5);
+  });
+});

--- a/chain/test/Competitions.winners.test.ts
+++ b/chain/test/Competitions.winners.test.ts
@@ -111,8 +111,11 @@ describe('Competitions. Sorting team results. Finding winners', () => {
       expect(prize0.votingResult).to.equal(votingResult);
       expect(prize0.rank).to.equal(rank);
     };
-    await checkNftMint(5, 1, 5);
-    await checkNftMint(4, 1, 5);
-    await checkNftMint(10, 1, 5);
+    // these teams all have a tied 1st place prize
+    await checkNftMint(true, 5, 1, 5);
+    await checkNftMint(true, 4, 1, 5);
+    await checkNftMint(true, 10, 1, 5);
+    // all other teams should not get any prize, as they have received zero votes
+    await checkNftMint(false, 1, 0, 0);
   });
 });

--- a/chain/test/Competitions.winners.test.ts
+++ b/chain/test/Competitions.winners.test.ts
@@ -95,6 +95,7 @@ describe('Competitions. Sorting team results. Finding winners', () => {
 
   it('teams should receive their minted NFTs', async () => {
     const checkNftMint = async (
+      shouldMint: boolean,
       teamIndex: number,
       rank: number,
       votingResult: number,

--- a/chain/test/Competitions.winners.test.ts
+++ b/chain/test/Competitions.winners.test.ts
@@ -9,6 +9,11 @@ import {
 } from '../typechain-types';
 import { deploy } from './util';
 
+/*
+This set of tests is for a scenario where there are multiple teams that are tied in 1st place
+because they have the same number of votes.
+Additionally all other teams have zero votes, and thus there is no 2nd place or 3rd place prizes.
+*/
 describe('Competitions. Sorting team results. Finding winners', () => {
   let governor: GovernorBallot;
   let voteToken: VoteToken;

--- a/chain/test/util.ts
+++ b/chain/test/util.ts
@@ -1,5 +1,5 @@
 import { BigNumberish, BytesLike, BigNumber } from 'ethers';
-import { ethers } from 'hardhat';
+import hre, { ethers } from 'hardhat';
 
 export type Proposal = [string[], BigNumberish[], BytesLike[], string];
 
@@ -25,4 +25,36 @@ export enum ProposalState {
   Queued,
   Expired,
   Executed,
+}
+
+export async function deploy() {
+  const signers = await hre.ethers.getSigners();
+  // deploy vote token
+  const VTFactory = await hre.ethers.getContractFactory('VoteToken');
+  const voteToken = await VTFactory.deploy();
+  await voteToken.deployed();
+  // mint NFTs
+  const mintTx = await voteToken.safeMintBatch(signers.map((s) => s.address));
+  await mintTx.wait();
+  // deploy Governor
+  const GovFactory = await hre.ethers.getContractFactory('GovernorBallot');
+  const governor = await GovFactory.deploy(voteToken.address);
+  await governor.deployed();
+  signers[0].sendTransaction({
+    to: governor.address,
+    value: hre.ethers.utils.parseEther('1'),
+  });
+  // deploy Competitions
+  const CompetitionsFactory = await hre.ethers.getContractFactory(
+    'Competitions',
+  );
+  const competitions = await CompetitionsFactory.deploy(governor.address);
+  await competitions.deployed();
+  // deploy Awards
+  const AwardsFactory = await hre.ethers.getContractFactory('Awards');
+  const awards = await AwardsFactory.deploy(competitions.address);
+  // set Awards address on the Competitions
+  const setAwardstx = await competitions.setAwards(awards.address);
+  await setAwardstx.wait();
+  return { signers, voteToken, governor, competitions, awards };
 }


### PR DESCRIPTION
## What
- added `Competitions.winners.test.ts` with team sorting / winners finding tests
- added checks for zero number of votes for a team (in `findWinners` and `onCompetitionEnd`)  to prevent setting ranks for such teams and to prevent minting to zero address
- now the `Competitions` owner can call `endCompetition` to execute proposal on the Governor. This is done to simplify Competitions interaction on the frontend (no need to construct a proposal again on execution). However the owner can still call the governor directly
- now a voter can call `getProposalId` before the voting to find out the Governor's `castVote` parameter (no need to calculate the ID manually)
- more failure scenarios tests