### PR TITLE
proposalVotes function

### DIFF
--- a/chain/README.md
+++ b/chain/README.md
@@ -12,14 +12,14 @@ Voting system is represented by smart contracts:
 
 - after deployment Competition owner has to link Competition s/c with Awards s/c by calling `setAwards` function
 - 250 teams can participate in a competition
-- a competition has to be [encoded as a usual Governor proposal](https://docs.openzeppelin.com/contracts/4.x/api/governance#IGovernor-propose-address---uint256---bytes---string-), where:
+- a new competition is started by calling RootstockGovernor's `createProposal` with 5 parameters [See details](https://docs.openzeppelin.com/contracts/4.x/api/governance#IGovernor-propose-address---uint256---bytes---string-):
   1. targets - `Competition` s/c address
   2. values - 0 (not sending any RBTC)
   3. calldatas - encoded call of Competition's function `onCompetitionEnd` with 2 parameters:
     - competition description, which has to be unique
     - array of participant addresses
   4. competition description (one more time)
-- a new competition is started by calling Competition's `propose` with these 4 parameters
+  5. Counting type (Simple or Ballot)
 - voting starts 1 block after proposal initiation 
 - the voting lasts a certain time (parameter of the Governor) and ends successfully if total votes number is more than a certain % of VoteToken holders (quorum, also Governor parameter)
 - voters can vote once for one of the teams in competition proposal by calling `castVote(uint256 proposalId, uint8 teamNumber)` on the Governor. 

--- a/chain/contracts/Competition.sol
+++ b/chain/contracts/Competition.sol
@@ -40,8 +40,14 @@ contract Competition is Ownable {
       teams.length > 1 && teams.length <= 250,
       'Competitions: Min 2, max 250 teams are allowed'
     );
-    uint256 proposalId = getProposalId(contestName, teams);
-    Team[][] memory winners = findWinners(proposalId, teams);
+    uint256 proposalId = governor.proposalIds(
+      keccak256(abi.encodePacked(contestName))
+    );
+    uint256[] memory votes = governor.proposalVotes(
+      proposalId,
+      uint8(teams.length)
+    );
+    Team[][] memory winners = findWinners(teams, votes);
     // runs 3 times, iterates ranks
     for (uint8 rank = 0; rank < winners.length; rank++) {
       // runs as many times as there are teams in the same rank (1-few)
@@ -58,25 +64,6 @@ contract Competition is Ownable {
     }
   }
 
-  // calculates successful competition ID
-  function getProposalId(
-    string calldata contestName,
-    address[] calldata teams
-  ) private view returns (uint256) {
-    address[] memory targets = new address[](1);
-    targets[0] = address(this);
-    uint256[] memory amounts = new uint256[](1);
-    amounts[0] = 0;
-    bytes[] memory calldatas = new bytes[](1);
-    calldatas[0] = abi.encodeWithSelector(
-      this.onCompetitionEnd.selector,
-      contestName,
-      teams
-    );
-    bytes32 descHash = keccak256(abi.encodePacked(contestName));
-    return governor.hashProposal(targets, amounts, calldatas, descHash);
-  }
-
   /* Finds winning teams.
   Returns a result like:
   [
@@ -89,18 +76,15 @@ contract Competition is Ownable {
   ]
    */
   function findWinners(
-    uint256 proposalId,
-    address[] memory teams
-  ) private view returns (Team[][] memory winners) {
+    address[] memory teams,
+    uint256[] memory votes
+  ) private pure returns (Team[][] memory winners) {
     winners = new Team[][](3);
     winners[0] = new Team[](1); // 1st place
     winners[1] = new Team[](1); // 2nd place
     winners[2] = new Team[](1); // 3rd place
     for (uint8 i = 0; i < teams.length; i++) {
-      Team memory team = Team({
-        addr: teams[i],
-        votes: governor.proposalVotes(proposalId, i + 1)
-      });
+      Team memory team = Team({addr: teams[i], votes: votes[i + 1]});
       if (team.votes == 0) continue;
       if (team.votes > winners[0][winners[0].length - 1].votes) {
         winners[2] = winners[1];

--- a/chain/contracts/Competition.sol
+++ b/chain/contracts/Competition.sol
@@ -41,7 +41,7 @@ contract Competition is Ownable {
       'Competitions: Min 2, max 250 teams are allowed'
     );
     uint256 proposalId = governor.proposalIds(
-      keccak256(abi.encodePacked(contestName))
+      uint256(keccak256(abi.encodePacked(contestName)))
     );
     uint256[] memory votes = governor.proposalVotes(
       proposalId,

--- a/chain/contracts/GovernorCountingUniversal.sol
+++ b/chain/contracts/GovernorCountingUniversal.sol
@@ -81,18 +81,18 @@ abstract contract GovernorCountingUniversal is Governor {
 
   /**
    * @dev `proposalVotes(uint256)` overload for Ballot counting mode. 
-   * Returns voting results for teams from 0 to `teams`
+   * Returns voting results for teams from 0 to `numTeams`
    * @param proposalId - Proposal ID
-   * @param teams - number of voting results to return.
+   * @param numTeams - number of voting results to return.
    * e.g. 5 returns voting results for teams 0 - 5, where 0 is assumed `Abstain`
-   * @return votes voting results for `teams` teams
+   * @return votes voting results for `numTeams` teams
    */
   function proposalVotes(
     uint256 proposalId,
-    uint8 teams
+    uint8 numTeams
   ) public view virtual returns (uint256[] memory votes) {
     require(
-      teams > 0 && teams <= 250,
+      numTeams > 0 && numTeams <= 250,
       'GovernorCountingUniversal: teams out of range'
     );
     ProposalVote storage proposalVote = _proposalVotes[proposalId];
@@ -100,8 +100,8 @@ abstract contract GovernorCountingUniversal is Governor {
       proposalVote.countingType == CountingType.Ballot,
       'GovernorCountingUniversal: Can be called only in Ballot mode)'
     );
-    votes = new uint256[](teams + 1);
-    for (uint8 i = 0; i <= teams; i++) {
+    votes = new uint256[](numTeams + 1);
+    for (uint8 i = 0; i <= numTeams; i++) {
       votes[i] = proposalVote.candidateVotes[i];
     }
   }

--- a/chain/contracts/RootstockGovernor.sol
+++ b/chain/contracts/RootstockGovernor.sol
@@ -23,8 +23,8 @@ contract RootstockGovernor is
     GovernorVotesQuorumFraction(6)
   {}
 
-  // proposal description hash => proposal ID
-  mapping(bytes32 => uint256) public proposalIds;
+  // proposal description => proposal ID association
+  mapping(uint256 => uint256) public proposalIds;
 
   function createProposal(
     address[] memory targets,
@@ -42,7 +42,7 @@ contract RootstockGovernor is
       revert('RootstockGovernor: unknown voting type');
     }
     // associate proposal description with proposal ID
-    proposalIds[keccak256(abi.encodePacked(description))] = proposalId;
+    proposalIds[uint256(keccak256(abi.encodePacked(description)))] = proposalId;
   }
 
   // The following functions are overrides required by Solidity.

--- a/chain/contracts/RootstockGovernor.sol
+++ b/chain/contracts/RootstockGovernor.sol
@@ -42,7 +42,12 @@ contract RootstockGovernor is
       revert('RootstockGovernor: unknown voting type');
     }
     // associate proposal description with proposal ID
-    proposalIds[uint256(keccak256(abi.encodePacked(description)))] = proposalId;
+    uint256 descriptionHash = uint256(keccak256(abi.encodePacked(description)));
+    require(
+      proposalIds[descriptionHash] == 0,
+      'RootstockGovernor: Proposal description should be unique'
+    );
+    proposalIds[descriptionHash] = proposalId;
   }
 
   // The following functions are overrides required by Solidity.

--- a/chain/contracts/RootstockGovernor.sol
+++ b/chain/contracts/RootstockGovernor.sol
@@ -23,6 +23,28 @@ contract RootstockGovernor is
     GovernorVotesQuorumFraction(6)
   {}
 
+  // proposal description hash => proposal ID
+  mapping(bytes32 => uint256) public proposalIds;
+
+  function createProposal(
+    address[] memory targets,
+    uint256[] memory values,
+    bytes[] memory calldatas,
+    string memory description,
+    CountingType countingType
+  ) external {
+    uint256 proposalId;
+    if (countingType == CountingType.Simple) {
+      proposalId = propose(targets, values, calldatas, description);
+    } else if (countingType == CountingType.Ballot) {
+      proposalId = proposeBallot(targets, values, calldatas, description);
+    } else {
+      revert('RootstockGovernor: unknown voting type');
+    }
+    // associate proposal description with proposal ID
+    proposalIds[keccak256(abi.encodePacked(description))] = proposalId;
+  }
+
   // The following functions are overrides required by Solidity.
 
   function votingDelay()

--- a/chain/test/Competitions.failure.test.ts
+++ b/chain/test/Competitions.failure.test.ts
@@ -1,7 +1,13 @@
 import hre from 'hardhat';
 import { mine, loadFixture } from '@nomicfoundation/hardhat-network-helpers';
 import { expect } from 'chai';
-import { deploy, getProposalId, Proposal, ProposalState } from '../util';
+import {
+  deploy,
+  getProposalId,
+  Proposal,
+  ProposalState,
+  CountingType,
+} from '../util';
 import { RootstockGovernor, Competition, VoteToken } from '../typechain-types';
 
 async function startCompetition(
@@ -25,7 +31,7 @@ async function startCompetition(
   ];
   const proposalId = getProposalId(proposal);
   // start the competition
-  const tx = await governor.proposeBallot(...proposal);
+  const tx = await governor.createProposal(...proposal, CountingType.Ballot);
   await tx.wait();
   await mine(2);
   return { proposal, teams, proposalId };
@@ -124,7 +130,10 @@ describe('Competition error path', () => {
     ];
     const proposalId = getProposalId(proposal);
     // start competition
-    const propose = await governor.proposeBallot(...proposal);
+    const propose = await governor.createProposal(
+      ...proposal,
+      CountingType.Ballot,
+    );
     await propose.wait();
     await mine(2);
     const vote = await governor.castVote(proposalId, 10);

--- a/chain/test/Competitions.winners.test.ts
+++ b/chain/test/Competitions.winners.test.ts
@@ -8,7 +8,7 @@ import {
   Competition,
   Awards,
 } from '../typechain-types';
-import { deploy, Proposal, getProposalId } from '../util';
+import { deploy, Proposal, getProposalId, CountingType } from '../util';
 
 /*
 This set of tests is for a scenario where there are multiple teams that are tied in 1st place
@@ -55,7 +55,7 @@ describe('Competitions. Sorting team results. Finding winners', () => {
     proposal = [[competition.address], [0], [callback], competitionName];
     proposalId = getProposalId(proposal);
     // start the competition
-    const tx = await governor.proposeBallot(...proposal);
+    const tx = await governor.createProposal(...proposal, CountingType.Ballot);
     await expect(tx).to.emit(governor, 'ProposalCreated');
   });
 
@@ -96,14 +96,17 @@ describe('Competitions. Sorting team results. Finding winners', () => {
   });
 
   it('teams not voted for should not have votes', async () => {
-    const proposalVotes = 'proposalVotes(uint256,uint8)';
-    expect(await governor[proposalVotes](proposalId, 1)).to.equal(0);
-    expect(await governor[proposalVotes](proposalId, 2)).to.equal(0);
-    expect(await governor[proposalVotes](proposalId, 3)).to.equal(0);
-    expect(await governor[proposalVotes](proposalId, 6)).to.equal(0);
-    expect(await governor[proposalVotes](proposalId, 7)).to.equal(0);
-    expect(await governor[proposalVotes](proposalId, 8)).to.equal(0);
-    expect(await governor[proposalVotes](proposalId, 9)).to.equal(0);
+    const proposalVotes = await governor['proposalVotes(uint256,uint8)'](
+      proposalId,
+      10,
+    );
+    expect(proposalVotes[0]).to.equal(0);
+    expect(proposalVotes[2]).to.equal(0);
+    expect(proposalVotes[3]).to.equal(0);
+    expect(proposalVotes[6]).to.equal(0);
+    expect(proposalVotes[7]).to.equal(0);
+    expect(proposalVotes[8]).to.equal(0);
+    expect(proposalVotes[9]).to.equal(0);
   });
 
   it('should execute the proposal and mint NFTs to the winners', async () => {

--- a/chain/test/RootstockGovernor.test.ts
+++ b/chain/test/RootstockGovernor.test.ts
@@ -9,6 +9,7 @@ import {
   ProposalState,
   VoteOptions,
   getProposalId,
+  CountingType,
 } from '../util';
 
 describe('Governor', () => {
@@ -42,7 +43,7 @@ describe('Governor', () => {
       description,
     ];
     proposalId = getProposalId(proposal);
-    const tx = await governor.propose(...proposal);
+    const tx = await governor.createProposal(...proposal, CountingType.Simple);
     await expect(tx).to.emit(governor, 'ProposalCreated');
   });
 

--- a/chain/util/index.ts
+++ b/chain/util/index.ts
@@ -33,6 +33,11 @@ export enum VoteOptions {
   Abstain,
 }
 
+export enum CountingType {
+  Simple, // each vote is either for, against, or abstain
+  Ballot, // each vote is for a single choice out of multiple choices
+}
+
 export async function deploy() {
   // deploy VoteToken NFT smart contract
   const VoteTokenFactory = await hre.ethers.getContractFactory('VoteToken');


### PR DESCRIPTION
## What
1. in the main governor `RootstockGovernor` created a function `createProposal`. It differs from `propose` with one last argument which is CountingType. This function should be used to create proposal of both types (Simple and Ballot). But the main purpose of this function is to keep track of proposal description hashes and associate them with proposal IDs. Otherwise it's very difficult in Competition's `onCompetitionEnd` to find out what proposal initially called the function.
2. In `GovernorCountingUniversal` modified the func `proposalVotes` which now returns an array of team votes instead of a single voting result. THis is done for convenience on the frontend